### PR TITLE
docs: update example config for TypeScript compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,19 @@ npm i --save-dev vite-plugin-turbosnap
 
 Add this plugin to `viteFinal` in your `.storybook/main.js`:
 
-```ts
+```js
 // .storybook/main.js
 
 const turbosnap = require('vite-plugin-turbosnap');
+const { mergeConfig } = require('vite');
 
 module.exports = {
   core: { builder: '@storybook/builder-vite' },
   async viteFinal(config, { configType }) {
-    // Turbosnap is only useful when building for production
-    if (configType === 'PRODUCTION') {
-      config.plugins.push(turbosnap({ rootDir: config.root }));
-    }
-
-    // ...And any other config you need to change...
-
-    // return the customized config
-    return config;
+    return mergeConfig(config, {
+      plugins: configType === 'PRODUCTION' ? [turbosnap({ rootDir: config.root ?? process.cwd() })] : [],
+      // ...And any other config you need to change...
+    });
   },
 ```
 


### PR DESCRIPTION
The example config specified in the README:

```js
// .storybook/main.js

const turbosnap = require('vite-plugin-turbosnap');

module.exports = {
  core: { builder: '@storybook/builder-vite' },
  async viteFinal(config, { configType }) {
    // Turbosnap is only useful when building for production
    if (configType === 'PRODUCTION') {
      config.plugins.push(turbosnap({ rootDir: config.root }));
    }

    // ...And any other config you need to change...

    // return the customized config
    return config;
  },
}
```

Produces errors in a `.storybook/main.ts` file.

1. `config.plugins` is possibly undefined.
2. `config.root` is possibly undefined.

![Screen Shot 2022-12-07 at 15 24 55](https://user-images.githubusercontent.com/630449/206309916-80f9e6d3-42bd-4858-b286-1c3497335064.png)

This PR updates the example to be compatible with JS and TS.