### PR TITLE
fix: normalize dep ids in StatsMap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,8 @@ export default function pluginTurbosnap({
     importers?: readonly string[]
   ): Module {
     return {
-      id: normalize(filename),
-      name: normalize(filename),
+      id: filename,
+      name: filename,
       reasons: createReasons(importers),
     };
   }
@@ -96,7 +96,8 @@ export default function pluginTurbosnap({
         mod.importedIds
           .concat(mod.dynamicallyImportedIds)
           .filter((name) => isUserCode(name))
-          .forEach((depId) => {
+          .forEach((depIdUnsafe) => {
+            const depId = normalize(depIdUnsafe);
             if (statsMap.has(depId)) {
               const m = statsMap.get(depId);
               if (m) {


### PR DESCRIPTION
This PR ensures a consistent representation of module ids in the statsMap. The updated code normalizes the depId before processing it.

It also hopefully closes #5 