### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Add this plugin to `viteFinal` in your `.storybook/main.js`:
 ```js
 // .storybook/main.js
 
-const turbosnap = require('vite-plugin-turbosnap');
-const { mergeConfig } = require('vite');
+import turbosnap from "vite-plugin-turbosnap";
+import { mergeConfig } from "vite";
 
-module.exports = {
+export default {
   // ... your existing storybook config
   async viteFinal(config, { configType }) {
     return mergeConfig(config, {
@@ -40,6 +40,7 @@ module.exports = {
       // ...And any other config you need to change...
     });
   },
+};
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const turbosnap = require('vite-plugin-turbosnap');
 const { mergeConfig } = require('vite');
 
 module.exports = {
-  core: { builder: '@storybook/builder-vite' },
+  // ... your existing storybook config
   async viteFinal(config, { configType }) {
     return mergeConfig(config, {
       plugins: configType === 'PRODUCTION' ? [turbosnap({ rootDir: config.root ?? process.cwd() })] : [],

--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ export default {
   // ... your existing storybook config
   async viteFinal(config, { configType }) {
     return mergeConfig(config, {
-      plugins: configType === 'PRODUCTION' ? [turbosnap({ rootDir: config.root ?? process.cwd() })] : [],
-      // ...And any other config you need to change...
+      plugins:
+        configType === "PRODUCTION"
+          ? [
+              turbosnap({
+                // This should be the base path of your storybook.  In monorepos, you may only need process.cwd().
+                rootDir: config.root ?? process.cwd(),
+              }),
+            ]
+          : [],
     });
   },
 };


### PR DESCRIPTION
This cleans up a few things in the example config:

- Moves to ESM syntax
- Removes unnecessary `core.builder` 6.5-style config
- Clarifies what `rootDir` means, closes https://github.com/IanVS/vite-plugin-turbosnap/issues/9